### PR TITLE
chore: Remove ERROR_CODES and ERRORS_MESSAGES, as backend now translates messages

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -325,16 +325,3 @@ export const USER_TYPE_OPTIONS: FormSelectOption[] = [
     label: t('FI User'),
   },
 ];
-
-// eslint-disable-next-line no-shadow
-export enum ERROR_CODES {
-  BORROWER_FIELD_VERIFICATION_MISSING = 'BORROWER_FIELD_VERIFICATION_MISSING',
-  DOCUMENT_VERIFICATION_MISSING = 'DOCUMENT_VERIFICATION_MISSING',
-  APPLICATION_ALREADY_COPIED = 'APPLICATION_ALREADY_COPIED',
-}
-
-export const ERRORS_MESSAGES: { [key: string]: string } = {
-  [ERROR_CODES.BORROWER_FIELD_VERIFICATION_MISSING]: t('Some borrower data field are not verified'),
-  [ERROR_CODES.DOCUMENT_VERIFICATION_MISSING]: t('Some documents are not verified'),
-  [ERROR_CODES.APPLICATION_ALREADY_COPIED]: t('A new application has alredy been created from this one'),
-};

--- a/src/hooks/useRejectApplication.ts
+++ b/src/hooks/useRejectApplication.ts
@@ -5,7 +5,7 @@ import { useSnackbar } from 'notistack';
 import { useNavigate } from 'react-router-dom';
 
 import { rejectApplicationFn } from '../api/private';
-import { DISPATCH_ACTIONS, ERRORS_MESSAGES, QUERY_KEYS } from '../constants';
+import { DISPATCH_ACTIONS, QUERY_KEYS } from '../constants';
 import { IApplication, RejectApplicationInput } from '../schemas/application';
 import useApplicationContext from './useSecureApplicationContext';
 
@@ -35,15 +35,9 @@ export default function useRejectApplication(): IUseRejectApplication {
     onError: (error) => {
       if (axios.isAxiosError(error) && error.response) {
         if (error.response.data && error.response.data.detail) {
-          if (ERRORS_MESSAGES[error.response.data.detail]) {
-            enqueueSnackbar(t(ERRORS_MESSAGES[error.response.data.detail]), {
-              variant: 'error',
-            });
-          } else {
-            enqueueSnackbar(t('Error: {error}', { error: error.response.data.detail }), {
-              variant: 'error',
-            });
-          }
+          enqueueSnackbar(t('Error: {error}', { error: error.response.data.detail }), {
+            variant: 'error',
+          });
         }
       } else {
         enqueueSnackbar(t('Error rejecting the application. {error}', { error }), {

--- a/src/util/validation.ts
+++ b/src/util/validation.ts
@@ -3,8 +3,6 @@ import axios from 'axios';
 import { EnqueueSnackbar } from 'notistack';
 import { ZodError, ZodType, z } from 'zod';
 
-import { ERRORS_MESSAGES } from '../constants';
-
 export class ValidationError extends Error {
   constructor(message: string, public readonly cause: ZodError) {
     super(message);
@@ -21,15 +19,9 @@ export const validation = <T extends ZodType>(schema: T, data: unknown, errorMes
 export const handleRequestError = (error: unknown, enqueueSnackbar: EnqueueSnackbar, defaultMessage: string) => {
   if (axios.isAxiosError(error) && error.response) {
     if (error.response.data && error.response.data.detail) {
-      if (ERRORS_MESSAGES[error.response.data.detail]) {
-        enqueueSnackbar(t(ERRORS_MESSAGES[error.response.data.detail]), {
-          variant: 'error',
-        });
-      } else {
-        enqueueSnackbar(t('Error: {error}', { error: error.response.data.detail }), {
-          variant: 'error',
-        });
-      }
+      enqueueSnackbar(t('Error: {error}', { error: error.response.data.detail }), {
+        variant: 'error',
+      });
     }
   } else {
     enqueueSnackbar(defaultMessage, {


### PR DESCRIPTION
Requires https://github.com/open-contracting/credere-backend/pull/382